### PR TITLE
Add leftover seconds to DurationFormat

### DIFF
--- a/chrono.inc
+++ b/chrono.inc
@@ -225,6 +225,17 @@ stock DurationFormat(Seconds:duration, output[], len = sizeof output) {
 		);
 	}
 
+	if(duration > Seconds:0) {
+		format(
+			output,
+			len,
+			"%s%d second%s",
+			output,
+			_:duration,
+			(_:duration > 1) ? ("s, ") : (", ")
+		);
+	}
+
 	// trim the trailing comma
 	output[strlen(output) - 2] = EOS;
 


### PR DESCRIPTION
Using this function when there's less than 60 seconds would simply return nothing. Not ideal for login timestamps and etc, so here's a quick fix. :)